### PR TITLE
Added xml comment toggle from Saphia Thach

### DIFF
--- a/lib/ace/mode/text.js
+++ b/lib/ace/mode/text.js
@@ -182,8 +182,66 @@ var Mode = function() {
         if (insertAtTabStop && minIndent % tabSize != 0)
             minIndent = Math.floor(minIndent / tabSize) * tabSize;
 
+        if (this.blockComment && startRow !== endRow) {
+            var initialRange = session.selection.toOrientedRange();
+            var range = {start: {row: startRow, column: 0}, end: {row: endRow, column: 0}};
+            toggleXmlComments(session, range, startRow, this.blockComment.start.length, initialRange, this.blockComment, !shouldRemove);
+        }
+
         iter(shouldRemove ? uncomment : comment);
     };
+
+    var toggleXmlComments = function (session, range, startRow, colDiff, initialRange, comment, escape) {
+        if (!(/<!--/.test(comment.start)) && !(/-->/.test(comment.end))) {
+            return;
+        }
+        if (!escape) {
+            if (range.start.row === startRow)
+                range.start.column += colDiff;
+            if (range.end.row === startRow)
+                range.end.column += colDiff;
+        }
+
+        var lines = session.getLines(range.start.row, range.end.row);
+        var updatedLines = [];
+
+        var toggleComment = function (line, escape) {
+            if (escape) {
+                return line.replace(/<!--/, "&lt;!&ndash;").replace(/-->/, "&ndash;&gt;");
+            } else {
+                return line.replace("&lt;!&ndash;", "<!--").replace("&ndash;&gt;","-->");
+            }
+        };
+
+        for (var i = 0; i < lines.length; i++) {
+            var line;
+            if (lines.length === 1) {
+                line = lines[i].substring(0,range.start.column);
+                line += toggleComment(lines[i].substring(range.start.column, range.end.column), escape);
+                line += lines[i].substring(range.end.column);
+            } else if (i === 0) {
+                line = lines[i].substring(0, range.start.column);
+                line += toggleComment(lines[i].substring(range.start.column), escape);
+            } else if (i === lines.length - 1) {
+                line = toggleComment(lines[i].substring(0, range.end.column), escape);
+                line += lines[i].substring(range.end.column);
+            } else {
+                line = toggleComment(lines[i], escape);
+            }
+            updatedLines.push(line);
+        }
+        session.doc.removeFullLines(range.start.row, range.end.row);
+        session.doc.insertFullLines(range.start.row, updatedLines);
+        if (range.end.row === startRow) {
+            var startDiff = updatedLines[0].length - lines[0].length;
+            range.end.column += startDiff;
+            initialRange.start.column += startDiff;
+        }
+        var endDiff = updatedLines[updatedLines.length - 1].length - lines[lines.length - 1].length;
+        range.end.column += endDiff;
+        initialRange.end.column +=endDiff;
+    };
+
 
     this.toggleBlockComment = function(state, session, range, cursor) {
         var comment = this.blockComment;
@@ -231,9 +289,11 @@ var Mode = function() {
                 startRow = startRange.start.row;
                 colDiff = -comment.start.length;
             }
+            toggleXmlComments(session, range, startRow, colDiff, initialRange, comment, false);
         } else {
             colDiff = comment.start.length;
             startRow = range.start.row;
+            toggleXmlComments(session, range, startRow, colDiff, initialRange, comment, true);
             session.insert(range.end, comment.end);
             session.insert(range.start, comment.start);
         }


### PR DESCRIPTION
Added xml comment toggle from Saphia Thach, made more generic and used in block / line comments

This enables IntelliJ style XML comment / uncomment (if an existing XML comment is found between the first and last rows of the block / line comment it will be escaped before commenting and  / un-escaped after uncommenting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
